### PR TITLE
Fix the composer installer in Docker

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,8 @@
 # Build backend source
-FROM composer as backend
+FROM php:7.4-apache as backend
+COPY --from=composer:1.10 /usr/bin/composer /usr/bin/composer
+
+RUN apt-get update && apt-get install -y git 
 
 #Install prestissimo for parallel composer installs
 #https://github.com/hirak/prestissimo/issues/148


### PR DESCRIPTION
This runs composer on PHP7.4 to install the dependancies instead of PHP8 which docker ships